### PR TITLE
Updated version dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://clojurekatas.org"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojure-contrib "1.2.0"]
                  [incanter "1.5.1"]]
   :main clojure-katas.core


### PR DESCRIPTION
The version listed in the dependencie will not work if one has a newer version of Clojure - even if the description says version 1.5 or up the program won't run with version 1.10.0 for example. If you are learning Clojure with Clojure for the Brave and True then you will have the latest version installed, changing the dependency here makes it possible to only need one verison of Coljure installed in order to run both the projects in the book as well as the clojure-katas.